### PR TITLE
Properly report non-registry override errors

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleFileFunction.java
@@ -241,6 +241,12 @@ public class ModuleFileFunction implements SkyFunction {
       if (repoDir == null) {
         return null;
       }
+      if (!repoDir.repositoryExists()) {
+        throw errorf(
+          Code.MODULE_NOT_FOUND,
+          "Non-registry override does not exist, reported reason: %s",
+          repoDir.getErrorMsg());
+      }
       RootedPath moduleFilePath =
           RootedPath.toRootedPath(
               Root.fromPath(repoDir.getPath()), LabelConstants.MODULE_DOT_BAZEL_FILE_NAME);


### PR DESCRIPTION
What motivated this change was the mistake of;

```
build --experimental_enable_bzlmod
query --experimental_enable_bzlmod
```

vs.

```
common --experimental_enable_bzlmod
```