### PR TITLE
Export CLI reference as JSON

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/HelpCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/HelpCommand.java
@@ -566,6 +566,7 @@ public final class HelpCommand implements BlazeCommand {
           Command annotation = command.getClass().getAnnotation(Command.class);
 
           Set<Class<? extends OptionsBase>> optionsClasses = new HashSet<>();
+          Collections.addAll(optionsClasses, annotation.options());
           for (BlazeModule blazeModule : runtime.getBlazeModules()) {
             Iterables.addAll(optionsClasses, blazeModule.getCommandOptions(annotation));
           }

--- a/src/main/java/com/google/devtools/build/lib/runtime/commands/HelpCommand.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/commands/HelpCommand.java
@@ -600,7 +600,7 @@ public final class HelpCommand implements BlazeCommand {
 
       // Commands
       {
-        JsonObject commandsObject = new JsonObject();
+        JsonArray commandsArray = new JsonArray();
         for (Map.Entry<String, BlazeCommand> e : commandsByName.entrySet()) {
           BlazeCommand command = e.getValue();
           Command annotation = command.getClass().getAnnotation(Command.class);
@@ -609,6 +609,10 @@ public final class HelpCommand implements BlazeCommand {
               replace("%{product}", runtime.getProductName());
 
           JsonObject commandInfoObject = new JsonObject();
+          commandInfoObject.add(
+            "name",
+            new JsonPrimitive(e.getKey())
+          );
           commandInfoObject.add(
             "shortDescription",
             new JsonPrimitive(shortDescription)
@@ -646,21 +650,18 @@ public final class HelpCommand implements BlazeCommand {
             );
           }
 
-          commandsObject.add(
-            e.getKey(),
-            commandInfoObject
-          );
+          commandsArray.add(commandInfoObject);
         }
 
         rootObject.add(
           "commands",
-          commandsObject
+          commandsArray
         );
       }
 
       // Option effect tags
       {
-        JsonObject optionEffectTagsObject = new JsonObject();
+        JsonArray optionEffectTagsArray = new JsonArray();
 
         String productName = runtime.getProductName();
         ImmutableMap<OptionEffectTag, String> effectTagDescriptions =
@@ -671,25 +672,26 @@ public final class HelpCommand implements BlazeCommand {
           String tagDescription = effectTagDescriptions.get(tag);
 
           optionEffectTagInfoObject.add(
+            "name",
+            new JsonPrimitive(tag.name().toLowerCase())
+          );
+          optionEffectTagInfoObject.add(
             "description",
             new JsonPrimitive(tagDescription)
           );
 
-          optionEffectTagsObject.add(
-            tag.name().toLowerCase(),
-            optionEffectTagInfoObject
-          );
+          optionEffectTagsArray.add(optionEffectTagInfoObject);
         }
 
         rootObject.add(
           "optionEffectTags",
-          optionEffectTagsObject
+          optionEffectTagsArray
         );
       }
 
       // Option metadata tags
       {
-        JsonObject optionMetadataTagsObject = new JsonObject();
+        JsonArray optionMetadataTagsArray = new JsonArray();
 
         String productName = runtime.getProductName();
         ImmutableMap<OptionMetadataTag, String> metadataTagDescriptions =
@@ -698,6 +700,10 @@ public final class HelpCommand implements BlazeCommand {
           JsonObject optionMetadataTagInfoObject = new JsonObject();
           String tagDescription = metadataTagDescriptions.get(tag);
 
+          optionMetadataTagInfoObject.add(
+            "name",
+            new JsonPrimitive(tag.name().toLowerCase())
+          );
           optionMetadataTagInfoObject.add(
             "description",
             new JsonPrimitive(tagDescription)
@@ -711,15 +717,12 @@ public final class HelpCommand implements BlazeCommand {
             new JsonPrimitive(tag.equals(OptionMetadataTag.INTERNAL))
           );
 
-          optionMetadataTagsObject.add(
-            tag.name().toLowerCase(),
-            optionMetadataTagInfoObject
-          );
+          optionMetadataTagsArray.add(optionMetadataTagInfoObject);
         }
 
         rootObject.add(
           "optionMetadataTags",
-          optionMetadataTagsObject
+          optionMetadataTagsArray
         );
       }
 
@@ -731,9 +734,15 @@ public final class HelpCommand implements BlazeCommand {
       outErr.printOut(gson.toJson(rootObject));
     }
 
-    private JsonArray generateOptionJson(OptionDefinition optDef, JsonArray associatedScopes) {
+    private JsonObject generateOptionJson(OptionDefinition optDef, JsonArray associatedScopes) {
       String productName = runtime.getProductName();
       JsonObject optionInfoObject = new JsonObject();
+
+      optionInfoObject.add(
+        "name",
+        new JsonPrimitive(optDef.getOptionName())
+      );
+
       if (!associatedScopes.isEmpty()) {
         optionInfoObject.add(
           "associatedScopes",
@@ -834,11 +843,7 @@ public final class HelpCommand implements BlazeCommand {
         );
       }
 
-      JsonArray pair = new JsonArray();
-      pair.add(new JsonPrimitive(optDef.getOptionName()));
-      pair.add(optionInfoObject);
-
-      return pair;
+      return optionInfoObject;
     }
 
     private static String capitalize(String s) {

--- a/src/main/java/com/google/devtools/common/options/OptionsParser.java
+++ b/src/main/java/com/google/devtools/common/options/OptionsParser.java
@@ -638,6 +638,18 @@ public class OptionsParser implements OptionsParsingResult {
         .forEach(visitor);
   }
 
+  public OptionDefinition[] getOptions() {
+    OptionsData data = impl.getOptionsData();
+    return data
+        .getOptionsClasses()
+        // List all options
+        .stream()
+        .flatMap(optionsClass -> OptionsData.getAllOptionDefinitionsForClass(optionsClass).stream())
+        // Sort field for deterministic ordering
+        .sorted(OptionDefinition.BY_OPTION_NAME)
+        .toArray(OptionDefinition[]::new);
+  }
+
   /**
    * Returns a description of the option.
    *


### PR DESCRIPTION
The goal of this prototype is to create a better CLI reference. With this extractor prototype completed, work on the UI/UX can now begin.

* [For Bazel 5.4.1](https://github.com/Silic0nS0ldier/bazel/compare/5.4.1...Silic0nS0ldier:bazel:jordan-mele_cli-docs_bazel-5.4.1?expand=1)
* [For Bazel 6.2.0](https://github.com/Silic0nS0ldier/bazel/compare/6.5.0...Silic0nS0ldier:bazel:jordan-mele_cli-docs_bazel-6.2.0?expand=1)
* [For Bazel 6.5.0](https://github.com/Silic0nS0ldier/bazel/compare/6.2.0...Silic0nS0ldier:bazel:jordan-mele_cli-docs_bazel-6.5.0?expand=1)
* [For Bazel 7.0.0](https://github.com/Silic0nS0ldier/bazel/compare/7.0.0...Silic0nS0ldier:bazel:jordan-mele_cli-docs_bazel-7.0.0?expand=1)
* [For Bazel 8.0.0-pre.20240108.6](https://github.com/Silic0nS0ldier/bazel/compare/8.0.0-pre.20240108.6...Silic0nS0ldier:bazel:jordan-mele_cli-docs_bazel-8.0.0-pre.20240108.6?expand=1)

Some notes on the data.

1. Select commands inherit options from an abnormal source. These options will have `configuration` in their `associatedScopes` property. Commands which inherit this will have `usesConfigurationOptions = true`.
2. Commands can inherit options, `build` being the best known example. `coverage` and `cquery` are outliers, inheriting from `test`.
3. To reduce repetition, all possible options have been consolidated into a single list. As hinted at in (1) `associatedScopes` indicates what a command belongs to (`(command)|startup|common|configuration`). Inheritance logic should be applied to this field to determine definitively if an option belongs to a command.
4. Normally hidden fields are included, though properties exist to detect if a field should be hidden.
5. Some fields may not make sense or be inconsistent with the existing Bazel CLI reference. There is business logic applied in other codepaths that this new code may not be applying. 

Sample output.
```json
{
    "options": [
        [
            "bazelrc",
            {
                "associatedScopes": [
                    "startup"
                ],
                "helpText": "The location of the user .bazelrc file containing default values of Bazel options. /dev/null indicates that all further `--bazelrc`s will be ignored, which is useful to disable the search for a user rc file, e.g. in release builds.\nThis option can also be specified multiple times.\nE.g. with `--bazelrc=x.rc --bazelrc=y.rc --bazelrc=/dev/null --bazelrc=z.rc`,\n  1) x.rc and y.rc are read.\n  2) z.rc is ignored due to the prior /dev/null.\nIf unspecified, Bazel uses the first .bazelrc file it finds in the following two locations: the workspace directory, then the user's home directory.\nNote: command line options will always supersede any option in bazelrc.",
                "abbreviation": null,
                "allowsMultiple": false,
                "hasNegativeOption": false,
                "isExpansionOption": false,
                "deprecationWarning": "",
                "oldName": "",
                "warnOldName": true,
                "documenationCategory": "bazel_client_options",
                "valueHelp": "<path>",
                "optionExpansions": [],
                "implicitRequirements": [],
                "optionEffectTags": [
                    "changes_inputs"
                ],
                "optionMetadataTags": []
            }
        ],
        ...
    },
    "commands": {
        "analyze-profile": {
            "shortDescription": "Analyzes build profile data.",
            "isHidden": false,
            "triggersBuild": false,
            "mustRunInWorkspace": false,
            "completion": "path",
            "usesConfigurationOptions": false,
            "inherits": []
        },
        ...
    },
    "optionEffectTags": {
        "unknown": {
            "description": "This option has unknown, or undocumented, effect."
        },
        ...
    },
    "optionMetadataTags": {
        "experimental": {
            "description": "This option triggers an experimental feature with no guarantees of functionality.",
            "hidden": false,
            "internal": false
        },
        ...
    }
}
```