### PR TITLE
Repro for bug JDK-8162455

### DIFF
--- a/src/test/shell/bazel/bazel_java_test.sh
+++ b/src/test/shell/bazel/bazel_java_test.sh
@@ -1960,5 +1960,41 @@ EOF
   expect_log "in pkg/Library.java: ''"
 }
 
+function test_unused_java_runfiles() {
+  cat >> WORKSPACE <<'EOF'
+EOF
+
+  mkdir -p pkg
+  cat > pkg/BUILD.bazel <<'EOF'
+java_binary(
+  name = "binary",
+  srcs = ["Binary.java"],
+  main_class = "com.example.Binary",
+  deps = [
+    "@bazel_tools//tools/java/runfiles",
+  ],
+)
+EOF
+
+  cat > pkg/Binary.java <<'EOF'
+package com.example;
+
+public class Binary {
+  private static class Class1 {
+  }
+
+  public static void main(String[] args) {
+    System.out.printf("in pkg/Binary.java: '%s'%n", "nada");
+  }
+}
+EOF
+
+  bazel run //pkg:binary &>"$TEST_log" || fail "Run should succeed"
+  expect_log "in pkg/Binary.java: 'nada'"
+
+  bazel run --javacopt="-Werror" //pkg:binary &>"$TEST_log" || fail "Run should succeed"
+  expect_log "in pkg/Binary.java: 'nada'"
+}
+
 
 run_suite "Java integration tests"


### PR DESCRIPTION
Repro for https://bugs.openjdk.org/browse/JDK-8162455 which was tripped over due to Bazel 6 now including a processor alongside `@bazel_tools//tools/java:runfiles` (`AutoBazelRepository`) which leads to warnings. When `--javacopy="-Werror"` flag is used, this warning causes build failures.

Workaround will be some permutation of `--javacopt="-Werror:-path`.