### PR TITLE
A hopefully functional prototype for filtering spawn strategies by platform

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -929,6 +929,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/starlarkbuildapi/platform",
         "//src/main/java/com/google/devtools/build/lib/util",
+        "//src/main/java/com/google/devtools/build/lib/exec:execution_options",
         "//third_party:guava",
     ],
 )

--- a/src/main/java/com/google/devtools/build/lib/analysis/PlatformConfiguration.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/PlatformConfiguration.java
@@ -31,7 +31,7 @@ import java.util.Map;
 
 /** A configuration fragment describing the current platform configuration. */
 @ThreadSafety.Immutable
-@RequiresOptions(options = {PlatformOptions.class})
+@RequiresOptions(options = {PlatformOptions.class, ExecutionOptions.class})
 public class PlatformConfiguration extends Fragment implements PlatformConfigurationApi {
   private final Label hostPlatform;
   private final ImmutableList<String> extraExecutionPlatforms;

--- a/src/main/java/com/google/devtools/build/lib/analysis/producers/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/producers/BUILD
@@ -65,6 +65,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/collect",
         "//src/main/java/com/google/devtools/build/lib/collect/nestedset",
         "//src/main/java/com/google/devtools/build/lib/events",
+        "//src/main/java/com/google/devtools/build/lib/exec:execution_options",
         "//src/main/java/com/google/devtools/build/lib/packages",
         "//src/main/java/com/google/devtools/build/lib/packages:configured_attribute_mapper",
         "//src/main/java/com/google/devtools/build/lib/packages:exec_group",

--- a/src/main/java/com/google/devtools/build/lib/analysis/producers/RuleTransitionApplier.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/producers/RuleTransitionApplier.java
@@ -32,6 +32,7 @@ import com.google.devtools.build.lib.analysis.platform.PlatformInfo;
 import com.google.devtools.build.lib.analysis.platform.PlatformValue;
 import com.google.devtools.build.lib.analysis.starlark.StarlarkTransition.TransitionException;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
+import com.google.devtools.build.lib.exec.ExecutionOptions;
 import com.google.devtools.build.lib.packages.RuleTransitionData;
 import com.google.devtools.build.lib.packages.Target;
 import com.google.devtools.build.lib.packages.TargetUtils;
@@ -141,10 +142,12 @@ public class RuleTransitionApplier
     ConfiguredTargetKey preRuleTransitionKey = targetAndConfigurationData.getPreRuleTransitionKey();
     var platformOptions =
         preRuleTransitionKey.getConfigurationKey().getOptions().get(PlatformOptions.class);
+    var executionOptions =
+        preRuleTransitionKey.getConfigurationKey().getOptions().get(ExecutionOptions.class);
     if (platformOptions == null) {
       unloadedToolchainContextsInputs = UnloadedToolchainContextsInputs.empty();
     } else {
-      platformConfiguration = new PlatformConfiguration(platformOptions);
+      platformConfiguration = new PlatformConfiguration(platformOptions, executionOptions);
       unloadedToolchainContextsInputs =
           ToolchainContextUtil.getUnloadedToolchainContextsInputs(
               target,

--- a/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelStrategyModule.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/rules/BazelStrategyModule.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.devtools.build.lib.analysis.actions.FileWriteActionContext;
 import com.google.devtools.build.lib.analysis.actions.TemplateExpansionContext;
 import com.google.devtools.build.lib.buildtool.BuildRequest;
+import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.exec.ExecutionOptions;
 import com.google.devtools.build.lib.exec.ModuleActionContextRegistry;
 import com.google.devtools.build.lib.exec.SpawnCache;
@@ -81,14 +82,18 @@ public class BazelStrategyModule extends BlazeModule {
 
     // By adding this filter before the ones derived from --strategy the latter can override the
     // former.
-    registryBuilder.addMnemonicFilter("Genrule", options.genruleStrategy);
+    registryBuilder.addMnemonicOverride("Genrule", options.genruleStrategy);
 
     for (Map.Entry<String, List<String>> strategy : options.strategy) {
-      registryBuilder.addMnemonicFilter(strategy.getKey(), strategy.getValue());
+      registryBuilder.addMnemonicOverride(strategy.getKey(), strategy.getValue());
     }
 
     for (Map.Entry<RegexFilter, List<String>> entry : options.strategyByRegexp) {
       registryBuilder.addDescriptionFilter(entry.getKey(), entry.getValue());
+    }
+
+    for (Map.Entry<String, List<String>> strategy : options.allowedStrategiesByExecPlatform) {
+      registryBuilder.addExecPlatformFilter(Label.parseCanonicalUnchecked(strategy.getKey()), strategy.getValue());
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/exec/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/exec/BUILD
@@ -107,6 +107,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/util:resource_converter",
         "//src/main/java/com/google/devtools/build/lib/vfs:pathfragment",
         "//src/main/java/com/google/devtools/common/options",
+        "//src/main/java/com/google/devtools/build/lib/analysis:config/fragment_options",
         "//third_party:guava",
     ],
 )
@@ -363,6 +364,7 @@ java_library(
         ":remote_local_fallback_registry",
         ":spawn_strategy_policy",
         "//src/main/java/com/google/devtools/build/lib/actions",
+        "//src/main/java/com/google/devtools/build/lib/cmdline",
         "//src/main/java/com/google/devtools/build/lib/events",
         "//src/main/java/com/google/devtools/build/lib/util",
         "//src/main/java/com/google/devtools/build/lib/util:abrupt_exit_exception",

--- a/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/exec/ExecutionOptions.java
@@ -16,6 +16,7 @@ package com.google.devtools.build.lib.exec;
 import com.google.common.collect.Iterables;
 import com.google.devtools.build.lib.actions.ActionExecutionContext;
 import com.google.devtools.build.lib.actions.ActionExecutionContext.ShowSubcommands;
+import com.google.devtools.build.lib.analysis.config.FragmentOptions;
 import com.google.devtools.build.lib.analysis.config.PerLabelOptions;
 import com.google.devtools.build.lib.util.CpuResourceConverter;
 import com.google.devtools.build.lib.util.OptionsUtils;
@@ -56,7 +57,7 @@ import java.util.Objects;
  * Ideally, the user would be unaware of the difference.  For now, the usage
  * strings are identical modulo "part 1", "part 2".
  */
-public class ExecutionOptions extends OptionsBase {
+public class ExecutionOptions extends FragmentOptions {
 
   public static final ExecutionOptions DEFAULTS = Options.getDefaults(ExecutionOptions.class);
 
@@ -93,6 +94,9 @@ public class ExecutionOptions extends OptionsBase {
       defaultValue = "null",
       documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
       effectTags = {OptionEffectTag.EXECUTION},
+      // TODO Shockingly, this lacks a usage example which makes it less obvious this is for
+      //      mnemonic targetted overrides.
+      //      Easy to mix up with --spawn_strategy
       help =
           "Specify how to distribute compilation of other spawn actions. Accepts a comma-separated"
               + " list of strategies from highest to lowest priority. For each action Bazel picks"
@@ -109,18 +113,42 @@ public class ExecutionOptions extends OptionsBase {
       documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
       effectTags = {OptionEffectTag.EXECUTION},
       defaultValue = "null",
-      help =
-          "Override which spawn strategy should be used to execute spawn actions that have "
-              + "descriptions matching a certain regex_filter. See --per_file_copt for details on"
-              + "regex_filter matching. "
-              + "The last regex_filter that matches the description is used. "
-              + "This option overrides other flags for specifying strategy. "
-              + "Example: --strategy_regexp=//foo.*\\.cc,-//foo/bar=local means to run actions "
-              + "using local strategy if their descriptions match //foo.*.cc but not //foo/bar. "
-              + "Example: --strategy_regexp='Compiling.*/bar=local "
-              + " --strategy_regexp=Compiling=sandboxed will run 'Compiling //foo/bar/baz' with "
-              + "the 'local' strategy, but reversing the order would run it with 'sandboxed'. ")
+      // TODO Document that this works as a filter
+      help = """
+        Override which spawn strategy should be used to execute spawn actions that have \
+        descriptions matching a certain regex_filter. See <code>--per_file_copt</code> for details on \
+        regex_filter matching.
+        The last regex_filter that matches the description is used.
+        This option overrides other flags for specifying strategy.
+        <br>
+        Example: <code>--strategy_regexp=//foo.*\\.cc,-//foo/bar=local</code> means to run actions \
+        using local strategy if their descriptions match <code>//foo.*.cc</code> but not <code>//foo/bar</code>.
+        <br>
+        Example: <code>--strategy_regexp='Compiling.*/bar=local</code> \
+        <code>--strategy_regexp=Compiling=sandboxed</code> will run <code>'Compiling //foo/bar/baz'</code> with
+        the <code>'local'</code> strategy, but reversing the order would run it with <code>'sandboxed'</code>.
+        """)
   public List<Map.Entry<RegexFilter, List<String>>> strategyByRegexp;
+
+  @Option(
+      name = "allowed_strategies_by_exec_platform",
+      allowMultiple = true,
+      converter = Converters.StringToStringListConverter.class,
+      defaultValue = "null",
+      documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
+      effectTags = {OptionEffectTag.EXECUTION},
+      help =
+          "")
+  public List<Map.Entry<String, List<String>>> allowedStrategiesByExecPlatform;
+
+  @Option(
+      name = "require_platform_scoped_strategies",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.EXECUTION_STRATEGY,
+      effectTags = {OptionEffectTag.EXECUTION},
+      help =
+          "")
+  public boolean requirePlatformScopedStrategies;
 
   @Option(
       name = "materialize_param_files",

--- a/src/test/java/com/google/devtools/build/lib/exec/SpawnStrategyRegistryTest.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/SpawnStrategyRegistryTest.java
@@ -77,7 +77,7 @@ public class SpawnStrategyRegistryTest {
         SpawnStrategyRegistry.builder()
             .registerStrategy(strategy1, "foo")
             .registerStrategy(strategy2, "bar")
-            .addMnemonicFilter("mnem", ImmutableList.of("bar", "foo"))
+            .addMnemonicOverride("mnem", ImmutableList.of("bar", "foo"))
             .build();
 
     assertThat(
@@ -100,7 +100,7 @@ public class SpawnStrategyRegistryTest {
         SpawnStrategyRegistry.builder(strategyPolicyProto)
             .registerStrategy(strategy1, "foo")
             .registerStrategy(strategy2, "bar")
-            .addMnemonicFilter("some-mnemonic", ImmutableList.of("bar", "foo"))
+            .addMnemonicOverride("some-mnemonic", ImmutableList.of("bar", "foo"))
             .build();
 
     assertThat(
@@ -172,7 +172,7 @@ public class SpawnStrategyRegistryTest {
             .registerStrategy(strategy3, "baz")
             .addDescriptionFilter(ELLO_MATCHER, ImmutableList.of("foo"))
             .addDescriptionFilter(LLO_MATCHER, ImmutableList.of("bar"))
-            .addMnemonicFilter("regex-mnemonic", ImmutableList.of("baz"))
+            .addMnemonicOverride("regex-mnemonic", ImmutableList.of("baz"))
             .build();
 
     List<? extends SpawnStrategy> strategies =
@@ -191,7 +191,7 @@ public class SpawnStrategyRegistryTest {
         SpawnStrategyRegistry.builder()
             .registerStrategy(strategy1, "foo")
             .registerStrategy(strategy2, "foo")
-            .addMnemonicFilter("mnem", ImmutableList.of("foo"))
+            .addMnemonicOverride("mnem", ImmutableList.of("foo"))
             .build();
 
     assertThat(
@@ -227,7 +227,7 @@ public class SpawnStrategyRegistryTest {
         SpawnStrategyRegistry.builder()
             .registerStrategy(strategy1, "foo")
             .registerStrategy(strategy2, "bar")
-            .addMnemonicFilter("mnem", ImmutableList.of("foo"))
+            .addMnemonicOverride("mnem", ImmutableList.of("foo"))
             .addDescriptionFilter(ELLO_MATCHER, ImmutableList.of("bar"))
             .build();
 
@@ -246,8 +246,8 @@ public class SpawnStrategyRegistryTest {
         SpawnStrategyRegistry.builder()
             .registerStrategy(strategy1, "foo")
             .registerStrategy(strategy2, "bar")
-            .addMnemonicFilter("mnem", ImmutableList.of("foo"))
-            .addMnemonicFilter("mnem", ImmutableList.of("bar"))
+            .addMnemonicOverride("mnem", ImmutableList.of("foo"))
+            .addMnemonicOverride("mnem", ImmutableList.of("bar"))
             .build();
 
     assertThat(
@@ -330,7 +330,7 @@ public class SpawnStrategyRegistryTest {
             .registerStrategy(strategy1, "foo")
             .registerStrategy(strategy2, "bar")
             .registerStrategy(strategy3, "baz")
-            .addMnemonicFilter("mnem", ImmutableList.of("bar"))
+            .addMnemonicOverride("mnem", ImmutableList.of("bar"))
             .setDefaultStrategies(ImmutableList.of("foo", "baz"))
             .build();
 
@@ -373,7 +373,7 @@ public class SpawnStrategyRegistryTest {
             () ->
                 SpawnStrategyRegistry.builder()
                     .registerStrategy(strategy1, "foo")
-                    .addMnemonicFilter("mnem", ImmutableList.of("bar", "foo"))
+                    .addMnemonicOverride("mnem", ImmutableList.of("bar", "foo"))
                     .build());
 
     assertThat(exception).hasMessageThat().containsMatch("bar.*Valid.*foo");
@@ -586,7 +586,7 @@ public class SpawnStrategyRegistryTest {
             .registerStrategy(strategy6, "6") // no notification: dynamic strategies are separate
             .registerStrategy(strategy8, "8") // no notification: never referenced
             .registerStrategy(strategy9, "9") // no notification: reference overridden
-            .addMnemonicFilter("mnem", ImmutableList.of("1"))
+            .addMnemonicOverride("mnem", ImmutableList.of("1"))
             .addDescriptionFilter(ELLO_MATCHER, ImmutableList.of("2"))
             .setDefaultStrategies(ImmutableList.of("9"))
             .setDefaultStrategies(ImmutableList.of("3"))
@@ -627,7 +627,7 @@ public class SpawnStrategyRegistryTest {
             .registerStrategy(strategy5, "5")
             .registerStrategy(strategy6, "6")
             .registerStrategy(strategy7, "7") // no notification: reference overridden
-            .addMnemonicFilter("mnem", ImmutableList.of("1"))
+            .addMnemonicOverride("mnem", ImmutableList.of("1"))
             .addDescriptionFilter(ELLO_MATCHER, ImmutableList.of("2"))
             .setDefaultStrategies(ImmutableList.of("3"))
             .setRemoteLocalFallbackStrategyIdentifier("4")

--- a/src/test/java/com/google/devtools/build/lib/exec/util/TestExecutorBuilder.java
+++ b/src/test/java/com/google/devtools/build/lib/exec/util/TestExecutorBuilder.java
@@ -132,7 +132,7 @@ public class TestExecutorBuilder {
 
   @CanIgnoreReturnValue
   public TestExecutorBuilder setExecution(String mnemonic, String strategy) {
-    strategyRegistryBuilder.addMnemonicFilter(mnemonic, ImmutableList.of(strategy));
+    strategyRegistryBuilder.addMnemonicOverride(mnemonic, ImmutableList.of(strategy));
     return this;
   }
 


### PR DESCRIPTION
Supersedes #6.

This is an untested (but mostly complete) prototype that will need to be iterated on further before it can be put up for formal review. This PR exists as a bookmark for myself.

## Manual Tests

- [x] Builds can complete successfully when new flags are unset.
- [ ] Builds fail if not all platforms have strategy filters and `--require_platform_scoped_strategies` is set.
- [ ] Builds pass if all platforms have strategy filters and `--require_platform_scoped_strategies` is set.
- [x] Platform filters actually filter strategies.