### PR TITLE
Periodically write collected metrics to profile

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/profiler/JsonTraceFileWriter.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/JsonTraceFileWriter.java
@@ -260,6 +260,8 @@ class JsonTraceFileWriter implements Runnable {
         int eventCount = 0;
         TraceData data;
         while ((data = takeData()) != POISON_PILL) {
+          // TODO collectors run on different threads
+          // We need to initiate periodic rejoins to drain them
           Preconditions.checkNotNull(data);
           eventCount++;
 

--- a/src/main/java/com/google/devtools/build/lib/profiler/Profiler.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/Profiler.java
@@ -357,6 +357,9 @@ public final class Profiler implements TraceProfilerService {
     public double[] toDoubleArray(int len) {
       return new double[len];
     }
+
+    @Override
+    public void clear() {}
   }
 
   private static class NoOpAsyncProfiler implements AsyncProfiler {

--- a/src/main/java/com/google/devtools/build/lib/profiler/TimeSeries.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/TimeSeries.java
@@ -29,4 +29,6 @@ public interface TimeSeries {
   void addRange(Duration rangeStart, Duration rangeEnd, double value);
 
   double[] toDoubleArray(int len);
+
+  void clear();
 }

--- a/src/main/java/com/google/devtools/build/lib/profiler/TimeSeriesImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/TimeSeriesImpl.java
@@ -91,4 +91,9 @@ public class TimeSeriesImpl implements TimeSeries {
   public synchronized double[] toDoubleArray(int len) {
     return Arrays.copyOf(data, len);
   }
+
+  @Override
+  public synchronized void clear() {
+    data = new double[INITIAL_SIZE];
+  }
 }

--- a/src/main/java/com/google/devtools/build/lib/profiler/TraceProfilerServiceImpl.java
+++ b/src/main/java/com/google/devtools/build/lib/profiler/TraceProfilerServiceImpl.java
@@ -367,6 +367,7 @@ public final class TraceProfilerServiceImpl implements TraceProfilerService {
     if (!active) {
       return;
     }
+    // could this also be logged as polled?
     collectActionCounts();
     localResourceCollector.stop();
     // Log a final event to update the duration of ProfilePhase.FINISH.

--- a/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/BlazeRuntime.java
@@ -483,6 +483,7 @@ public final class BlazeRuntime implements BugReport.BlazeRuntimeInterface {
                     commandOptions.collectResourceEstimation,
                     commandOptions.collectPressureStallIndicators,
                     commandOptions.collectSkyframeCounts,
+                    commandOptions.metricsBatchSize,
                     getBlazeService(SystemNetworkStatsService.class)));
         // Instead of logEvent() we're calling the low level function to pass the timings we took in
         // the launcher. We're setting the INIT phase marker so that it follows immediately the

--- a/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/runtime/CommonCommandOptions.java
@@ -446,6 +446,20 @@ public class CommonCommandOptions extends OptionsBase {
   public boolean collectSkyframeCounts;
 
   @Option(
+      name = "experimental_metrics_batch_size",
+      defaultValue = "0",
+      documentationCategory = OptionDocumentationCategory.LOGGING,
+      effectTags = {OptionEffectTag.BAZEL_MONITORING},
+      help = """
+          Number of data points to collect before writing metrics to the profile. 0 (default) \
+          waits until the end, 1 writes after every data point.
+
+          Lower values reduce data loss in the event of a crash, but may hurt performance.
+      """
+  )
+  public int metricsBatchSize;
+
+  @Option(
       name = "memory_profile",
       defaultValue = "null",
       documentationCategory = OptionDocumentationCategory.LOGGING,

--- a/src/test/shell/bazel/BUILD
+++ b/src/test/shell/bazel/BUILD
@@ -1474,6 +1474,10 @@ sh_test(
     srcs = ["profile_test.sh"],
     data = [
         ":test-deps",
+        "//scripts:jq",
         "@bazel_tools//tools/bash/runfiles",
     ],
+    env = {
+        "JQ_RLOCATIONPATH": "$(rlocationpath //scripts:jq)",
+    },
 )


### PR DESCRIPTION
Work in progress.

There aren't really any downsides with this change beyond threads syncing routinely (instead of just during command finalisation). Well worth it for diagnosing issues that kill Bazel, and the threshold can be increased if it does become a problem.

Current issue is threading. Thread managing the profiler needs to initiate a join in order for data to be collected.