### PR TITLE
Enrich download metrics with URL(s) and failure reasons

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadManager.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/downloader/DownloadManager.java
@@ -139,6 +139,8 @@ public class DownloadManager {
             // Not in download phase, must already have been cancelled.
             throw new InterruptedException();
           }
+          // TODO we can do better with this span - dedicated ProfilerTask.___,
+          // more metadata, etc.
           try (SilentCloseable c = Profiler.instance().profile("fetching: " + context)) {
             return downloadInExecutor(
                 originalUrls,
@@ -330,6 +332,7 @@ public class DownloadManager {
 
     for (int attempt = 0; ; ++attempt) {
       try {
+        // real data is known here, does this create a profile span?
         downloader.download(
             rewrittenUrls,
             headers,

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -622,9 +622,13 @@ public abstract class StarlarkBaseExternalContext implements AutoCloseable, Star
       }
     } catch (IOException e) {
       if (pendingDownload.allowFail) {
+        // include failure reason
         return StarlarkInfo.create(
             StructProvider.STRUCT, ImmutableMap.of("success", false), Location.BUILTIN);
       } else {
+        // transient download errors are discarded due to retries
+        // these need to be logged
+        // perhaps a "maybe transient" option is needed?
         throw new RepositoryFunctionException(e, Transience.TRANSIENT);
       }
     } catch (InvalidPathException e) {


### PR DESCRIPTION
Work in progress (just comments right now).

Currently download issues (namely those considered transient) are very difficult to diagnose in hands-off environments like CI. This seeks to fill gaps in the profiler and logging.
