### PR TITLE
WIP `attr.data` for generic data input

### DIFF
--- a/src/main/java/com/google/devtools/build/docgen/RuleDocumentationAttribute.java
+++ b/src/main/java/com/google/devtools/build/docgen/RuleDocumentationAttribute.java
@@ -180,6 +180,7 @@ public class RuleDocumentationAttribute
       case LABEL_LIST_DICT -> BuildType.LABEL_LIST_DICT;
       case OUTPUT -> BuildType.OUTPUT;
       case OUTPUT_LIST -> BuildType.OUTPUT_LIST;
+      case DATA -> Types.DATA;
       default ->
           throw new BuildEncyclopediaDocException(
               location,

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkAttrModule.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkAttrModule.java
@@ -1169,6 +1169,19 @@ public final class StarlarkAttrModule implements StarlarkAttrModuleApi {
   }
 
   @Override
+  public Descriptor dataAttribute(
+      StarlarkThread thread)
+      throws EvalException {
+    checkContext(thread, "attr.data()");
+    return createAttrDescriptor(
+        "data",
+        Optional.empty(),
+        optionMap(),
+        Types.DATA,
+        thread);
+  }
+
+  @Override
   public Descriptor licenseAttribute(
       Object defaultValue, Object doc, Boolean mandatory, StarlarkThread thread)
       throws EvalException {

--- a/src/main/java/com/google/devtools/build/lib/packages/AttributeFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/AttributeFormatter.java
@@ -202,7 +202,7 @@ public class AttributeFormatter {
     attrPb.setSelectorList(selectorListBuilder);
   }
 
-  /**
+  /**TODO
    * Set the appropriate type and value. Since string and string list store values for multiple
    * types, use the toString() method on the objects instead of casting them.
    */

--- a/src/main/java/com/google/devtools/build/lib/packages/ProtoUtils.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/ProtoUtils.java
@@ -46,7 +46,7 @@ import com.google.devtools.build.lib.query2.proto.proto2api.Build.Attribute.Disc
 /** Shared code used in proto buffer output for rules and rule classes. */
 public class ProtoUtils {
   /** This map contains all attribute types that are recognized by the protocol output formatter. */
-  private static final ImmutableMap<Type<?>, Discriminator> TYPE_MAP =
+  private static final ImmutableMap<Type<?>, Discriminator> TYPE_MAP = // TODO
       new ImmutableMap.Builder<Type<?>, Discriminator>()
           .put(INTEGER, Discriminator.INTEGER)
           .put(LABEL, Discriminator.LABEL)

--- a/src/main/java/com/google/devtools/build/lib/packages/Types.java
+++ b/src/main/java/com/google/devtools/build/lib/packages/Types.java
@@ -17,6 +17,7 @@ package com.google.devtools.build.lib.packages;
 import com.google.devtools.build.lib.packages.Type.DictType;
 import com.google.devtools.build.lib.packages.Type.ListType;
 import com.google.devtools.build.lib.packages.Type.SetType;
+import com.google.devtools.build.lib.packages.Type.DataType;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.SerializationConstant;
 import java.util.List;
 import net.starlark.java.eval.StarlarkInt;
@@ -50,6 +51,9 @@ public final class Types {
   @SerializationConstant
   public static final DictType<String, List<String>> STRING_LIST_DICT =
       DictType.create(Type.STRING, STRING_LIST);
+    
+  @SerializationConstant
+  public static final DataType DATA = new DataType();
 
   private Types() {}
 }

--- a/src/main/java/com/google/devtools/build/lib/query2/query/output/ProtoOutputFormatter.java
+++ b/src/main/java/com/google/devtools/build/lib/query2/query/output/ProtoOutputFormatter.java
@@ -516,7 +516,7 @@ public class ProtoOutputFormatter extends AbstractUnorderedFormatter {
    */
   @Nullable
   @SuppressWarnings("unchecked")
-  private static Object getFlattenedAttributeValues(Type<?> attrType, Rule rule, Attribute attr) {
+  private static Object getFlattenedAttributeValues(Type<?> attrType, Rule rule, Attribute attr) {// TODO
     boolean treatMultipleAsNone = SCALAR_TYPES.contains(attrType);
     Iterable<Object> possibleValues =
         PossibleAttributeValues.forRuleAndAttribute(rule, attr, treatMultipleAsNone);

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkAttrModuleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkAttrModuleApi.java
@@ -1331,6 +1331,21 @@ public interface StarlarkAttrModuleApi extends StarlarkValue {
       throws EvalException;
 
   @StarlarkMethod(
+      name = "data",
+      doc = """
+        Creates a schema for a data-only attribute that accepts structured data.
+        Accepts;
+        <ul>
+          <li>All starlark data types except functions; such as <code>list</code>, <code>dict</code>, and <code>string</code>.</li>
+          <li><code>Label</code>s.</li>
+        </ul>
+        """,
+      useStarlarkThread = true)
+  Descriptor dataAttribute(
+      StarlarkThread thread)
+      throws EvalException;
+
+  @StarlarkMethod(
       name = "license",
       doc = "Creates a schema for a license attribute.",
       // TODO(bazel-team): Implement proper license support for Starlark.

--- a/src/main/java/com/google/devtools/build/lib/starlarkdocextract/AttributeInfoExtractor.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkdocextract/AttributeInfoExtractor.java
@@ -108,7 +108,7 @@ public final class AttributeInfoExtractor {
     }
   }
 
-  static AttributeType getAttributeType(
+  static AttributeType getAttributeType(// TODO
       ExtractorContext context, Type<?> type, String attributePublicName) {
     if (type.equals(Type.INTEGER)) {
       return AttributeType.INT;

--- a/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
+++ b/src/test/java/com/google/devtools/build/lib/bazel/bzlmod/ModuleExtensionResolutionTest.java
@@ -3020,7 +3020,7 @@ public class ModuleExtensionResolutionTest extends BuildViewTestCase {
   }
 
   @Test
-  public void extensionRepoMapping() throws Exception {
+  public void extensionRepoMapping() throws Exception {// TODO
     scratch.overwriteFile(
         "MODULE.bazel",
         """

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkRuleClassFunctionsTest.java
@@ -709,6 +709,13 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
   }
 
   @Test
+  public void testDataAttr() throws Exception {
+    Attribute attr = buildAttribute("a1", "attr.data()");
+    assertThat(attr.starlarkDefined()).isTrue();
+    assertThat(attr.getType()).isEqualTo(Types.DATA);
+  }
+
+  @Test
   public void testAttrAllowedFileTypesAnyFile() throws Exception {
     Attribute attr = buildAttribute("a1", "attr.label_list(allow_files = True)");
     assertThat(attr.starlarkDefined()).isTrue();
@@ -1641,7 +1648,7 @@ public final class StarlarkRuleClassFunctionsTest extends BuildViewTestCase {
         ev,
         "attr.label(default=f)",
         "attr.label_list(default=f)",
-        "attr.label_keyed_string_dict(default=f)");
+        "attr.label_keyed_string_dict(default=f)");// TODO
     // For all other attribute types, the default value may not be a function.
     //
     // (This is a regression test for github.com/bazelbuild/bazel/issues/9463.

--- a/src/test/java/com/google/devtools/build/lib/starlark/StarlarkStringRepresentationsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlark/StarlarkStringRepresentationsTest.java
@@ -395,6 +395,7 @@ public class StarlarkStringRepresentationsTest extends BuildViewTestCase {
     assertStringRepresentation("attr.string_dict()", "<attr.string_dict>");
     assertStringRepresentation("attr.string_list_dict()", "<attr.string_list_dict>");
     assertStringRepresentation("attr.label_list_dict()", "<attr.label_list_dict>");
+    assertStringRepresentation("attr.data()", "<attr.data>");
   }
 
   @Test

--- a/src/test/java/com/google/devtools/build/lib/starlarkdocextract/ModuleInfoExtractorTest.java
+++ b/src/test/java/com/google/devtools/build/lib/starlarkdocextract/ModuleInfoExtractorTest.java
@@ -830,6 +830,7 @@ public final class ModuleInfoExtractorTest {
                     "k": attr.output(),
                     "l": attr.output_list(),
                     "m": attr.label_list_dict(),
+                    "n": attr.data(),
                 },
             )
             """);
@@ -905,6 +906,11 @@ public final class ModuleInfoExtractorTest {
                         .setName("m")
                         .setType(AttributeType.LABEL_LIST_DICT)
                         .setDefaultValue("{}")
+                        .build(),
+                    AttributeInfo.newBuilder()
+                        .setName("n")
+                        .setType(AttributeType.DATA)
+                        .setDefaultValue("None")
                         .build())
                 .build());
   }
@@ -1136,6 +1142,7 @@ my_macro = macro(
 
   @Test
   public void labelStringification() throws Exception {
+    // TODO
     Module module =
         exec(
             """

--- a/src/test/py/bazel/BUILD
+++ b/src/test/py/bazel/BUILD
@@ -51,6 +51,13 @@ py_test(
 )
 
 py_test(
+    name = "attributes_test",
+    size = "medium",
+    srcs = ["attributes_test.py"],
+    deps = [":test_base"],
+)
+
+py_test(
     name = "cc_import_test",
     size = "large",
     srcs = ["cc_import_test.py"],

--- a/src/test/py/bazel/attributes_test.py
+++ b/src/test/py/bazel/attributes_test.py
@@ -1,0 +1,35 @@
+# Copyright 2023 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from src.test.py.bazel import test_base
+
+class AttributesTest(test_base.TestBase):
+
+    def setUp(self):
+        test_base.TestBase.setUp(self)
+
+    def testAttributeEquivilence_rule(self):
+        pass
+
+    def testAttributeEquivilence_macro(self):
+        pass
+
+    def testAttributeEquivilence_aspect(self):
+        pass
+
+    def testAttributeEquivilence_repositoryRule(self):
+        pass
+
+    def testAttributeEquivilence_moduleExtension(self):
+        pass


### PR DESCRIPTION
Pass structured data into rules without needing needing to resort to hacks like `json.encode`.

By design, this only supports basic data types and _maybe_ `Label` (although crucially these will not be replaced with `Target`, support for `Label` would only be to simplify comparisons against `Target.label`).

The name `data` is subject to change. The existing common attribute `data` is a source of confusion.