### PR TITLE
Granular repository caching

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryOptions.java
@@ -97,6 +97,40 @@ public class RepositoryOptions extends OptionsBase {
   public Duration repoContentsCacheGcIdleDelay;
 
   @Option(
+      name = "experimental_granular_repository_caching",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.BAZEL_CLIENT_OPTIONS,
+      effectTags = {OptionEffectTag.BAZEL_INTERNAL_CONFIGURATION},
+      help =
+          """
+          Enables a more granular caching strategy for repository contents that is compatible with
+          remote caching setups where AC entries are only allowed from remotely executed actions.
+
+          When enabled, <code>repository_ctx</code> operations become synonmous with rule actions.
+          That is, operations like <code>execute</code> act more like <code>ctx.actions.run</code>
+          meaning they can be persisted in the action cache and executed remotely.
+
+          Note that repository rules with <code>local = True</code> will have their
+          <code>execute</code> operations still run locally and not participate in caching.
+
+          Note that <code>execute</code> operations that run outside of the repository (
+          e.g. absolute path or relative path outside of the repository) are excempt.
+          TODO Should this behaviour be made to require `local = True`?
+
+          Downloads without an integrity hash are likewise exempt.
+
+          The following operations are currently supported:
+          <ul>
+            <li><code>ctx.execute</code></li>
+            <li><code>ctx.download</code></li>
+            <li><code>ctx.download_and_extract</code></li>
+            <li><code>ctx.read</code></li>
+            <li><code>ctx.write</code></li>
+          </ul>
+          """)
+  public boolean useGranularRepositoryCaching;
+
+  @Option(
       name = "registry",
       defaultValue = "null",
       allowMultiple = true,

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkBaseExternalContext.java
@@ -775,6 +775,9 @@ When <code>sha256</code> or <code>integrity</code> is user specified, setting an
       Boolean block,
       StarlarkThread thread)
       throws RepositoryFunctionException, EvalException, InterruptedException {
+    
+    // TODO(Silic0nS0ldier): --experimental_granular_repository_caching
+
     PendingDownload download = null;
     ImmutableMap<URI, Map<String, List<String>>> authHeaders =
         getAuthHeaders(getAuthContents(authUnchecked, "auth"));
@@ -1030,6 +1033,9 @@ the same path on case-insensitive filesystems.
       String oldStripPrefix,
       StarlarkThread thread)
       throws RepositoryFunctionException, InterruptedException, EvalException {
+
+    // TODO(Silic0nS0ldier): --experimental_granular_repository_caching
+
     stripPrefix = renamedStripPrefix("download_and_extract", stripPrefix, oldStripPrefix);
     ImmutableMap<URI, Map<String, List<String>>> authHeaders =
         getAuthHeaders(getAuthContents(authUnchecked, "auth"));
@@ -1290,6 +1296,9 @@ the same path on case-insensitive filesystems.
       String type,
       StarlarkThread thread)
       throws RepositoryFunctionException, InterruptedException, EvalException {
+
+    // TODO(Silic0nS0ldier): --experimental_granular_repository_caching
+
     stripPrefix = renamedStripPrefix("extract", stripPrefix, oldStripPrefix);
     StarlarkPath archivePath = getPath(archive);
 
@@ -1418,6 +1427,9 @@ the same path on case-insensitive filesystems.
   public void createFile(
       Object path, String content, Boolean executable, Boolean legacyUtf8, StarlarkThread thread)
       throws RepositoryFunctionException, EvalException, InterruptedException {
+
+    // TODO(Silic0nS0ldier): --experimental_granular_repository_caching
+    
     StarlarkPath p = getPath(path);
     WorkspaceRuleEvent w =
         WorkspaceRuleEvent.newFileEvent(
@@ -1896,7 +1908,7 @@ the same path on case-insensitive filesystems.
     return b.toString();
   }
 
-  @StarlarkMethod(
+  @StarlarkMethod(// here
       name = "execute",
       doc =
           """
@@ -1954,6 +1966,10 @@ the same path on case-insensitive filesystems.
       StarlarkThread thread)
       throws EvalException, RepositoryFunctionException, InterruptedException {
     validateExecuteArguments(arguments);
+
+    // TODO(Silic0nS0ldier): --experimental_granular_repository_caching
+    
+
     int timeout = Starlark.toInt(timeoutI, "timeout");
 
     Map<String, Object> forceRepoEnvVariablesRaw =

--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/starlark/StarlarkRepositoryContext.java
@@ -215,6 +215,9 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
       })
   public void symlink(Object target, Object linkName, StarlarkThread thread)
       throws RepositoryFunctionException, EvalException, InterruptedException {
+
+    // TODO(Silic0nS0ldier): --experimental_granular_repository_caching
+
     StarlarkPath targetPath = getPath(target);
     StarlarkPath linkPath = getPath(linkName);
     WorkspaceRuleEvent w =
@@ -307,6 +310,9 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
       String watchTemplate,
       StarlarkThread thread)
       throws RepositoryFunctionException, EvalException, InterruptedException {
+
+    // TODO(Silic0nS0ldier): --experimental_granular_repository_caching
+
     StarlarkPath p = getPath(path);
     StarlarkPath t = getPath(template);
     Map<String, String> substitutionMap =
@@ -354,6 +360,7 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
     return repoDefinition.repoRule().remotable();
   }
 
+  // TODO look at how this is used --experimental_granular_repository_caching
   @Override
   protected ImmutableMap<String, String> getRemoteExecProperties() throws EvalException {
     return ImmutableMap.copyOf(
@@ -381,6 +388,9 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
       })
   public boolean delete(Object pathObject, StarlarkThread thread)
       throws EvalException, RepositoryFunctionException, InterruptedException {
+
+    // TODO(Silic0nS0ldier): --experimental_granular_repository_caching
+    
     StarlarkPath starlarkPath = externalPath("delete()", pathObject);
     WorkspaceRuleEvent w =
         WorkspaceRuleEvent.newDeleteEvent(
@@ -432,6 +442,9 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
       })
   public void rename(Object srcName, Object dstName, StarlarkThread thread)
       throws RepositoryFunctionException, EvalException, InterruptedException {
+
+    // TODO(Silic0nS0ldier): --experimental_granular_repository_caching
+      
     StarlarkPath srcPath = getPath(srcName);
     StarlarkPath dstPath = getPath(dstName);
     WorkspaceRuleEvent w =
@@ -510,6 +523,9 @@ public class StarlarkRepositoryContext extends StarlarkBaseExternalContext {
       })
   public void patch(Object patchFile, StarlarkInt stripI, String watchPatch, StarlarkThread thread)
       throws EvalException, RepositoryFunctionException, InterruptedException {
+
+    // TODO(Silic0nS0ldier): --experimental_granular_repository_caching
+
     int strip = Starlark.toInt(stripI, "strip");
     StarlarkPath starlarkPath = getPath(patchFile);
     WorkspaceRuleEvent w =


### PR DESCRIPTION
WIP

Goal is for repository operations (`write`, `execute`, `download(_and_extract)`, `extract`, `symlink`) to be;
1. Are cache-able (so a `http_archive` rule won't need to re-extract when patches change).
2. Can be run remotely (where it makes sense, `write` is a direct insert into remote caches).
3. Cache-able remotely in environments where clients are not allowed to upload action results (e.g. for security).

The repository implementation function still runs and repo rules aren't required to be reproducible (although it will hurt cache hit rates). Repo rules with `local = True` are exempt as they are explicitly marked as relying on the local system (e.g. references locally installed compiler toolchains).

A fully remotely cached repository will have files lazily downloaded like with `--experimental_remote_repo_contents_cache`.