### PR TITLE
Improve docs for `subrules` and `parent`

### DIFF
--- a/site/en/extending/rules.md
+++ b/site/en/extending/rules.md
@@ -1175,6 +1175,137 @@ validation_outputs_test = analysistest.make(_validation_outputs_test_impl)
 Running validation actions is controlled by the `--run_validations` command line
 flag, which defaults to true.
 
+## Rule extensibility {:#rule_extensibility}
+
+Several mechanisms for sharing logic and extending rules beyond
+what a single `rule()` definition offers.
+
+### Subrules {:#subrules}
+
+A *subrule* encapsulates a reusable piece of rule implementation logic —
+typically a set of actions that depend on private tools or files — so it can be
+shared across multiple rules and aspects without repeating attribute declarations
+or implementation code.
+
+#### Defining a subrule
+
+Use the [`subrule`](/rules/lib/globals/bzl#subrule) function in a `.bzl` file.
+A subrule has an `implementation` function and an optional `attrs` dictionary
+(label-typed attributes only, all private). It must be assigned to a global
+variable before it can be used:
+
+```python
+def _compile_impl(ctx, _compiler):
+    output = ctx.actions.declare_file(ctx.label.name + ".out")
+    ctx.actions.run(
+        executable = _compiler,
+        inputs = [],
+        outputs = [output],
+    )
+    return output
+
+_compile = subrule(
+    implementation = _compile_impl,
+    attrs = {
+        "_compiler": attr.label(
+            default = "//tools:compiler",
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+)
+```
+
+#### Using a subrule from a rule or aspect
+
+Any rule or aspect that calls a subrule must declare it in its `subrules`
+parameter. The subrule's private attributes are automatically lifted onto the
+declaring rule or aspect and are invisible to its users:
+
+```python
+def _my_rule_impl(ctx):
+    out = _compile()
+    return [DefaultInfo(files = depset([out]))]
+
+my_rule = rule(
+    implementation = _my_rule_impl,
+    subrules = [_compile],
+)
+```
+
+The same applies to aspects:
+
+```python
+_my_aspect = aspect(
+    implementation = _my_aspect_impl,
+    subrules = [_compile],
+)
+```
+
+#### Composing subrules
+
+A subrule can depend on other subrules by listing them in its own `subrules`
+parameter. The transitive closure of subrule dependencies is collected
+automatically; only the top-level subrule needs to be declared in the consuming
+rule or aspect:
+
+```python
+_link = subrule(
+    implementation = _link_impl,
+    subrules = [_compile],  # _compile's attrs are lifted automatically
+)
+
+my_rule = rule(
+    implementation = _my_rule_impl,
+    subrules = [_link],  # no need to also list _compile
+)
+```
+
+### Rule inheritance {:#rule_inheritance}
+
+A rule can extend another rule using the `parent` parameter of
+[`rule`](/rules/lib/globals/bzl#rule). The child rule inherits the parent's public
+attributes and advertised providers. `executable` and `test` are matched from the
+parent. `fragments`, `toolchains`, `exec_compatible_with`, and `exec_groups` are
+merged between parent and child.
+
+```python
+# parent.bzl
+def _parent_impl(ctx):
+    ...
+
+parent_rule = rule(
+    implementation = _parent_impl,
+    extendable = True,
+    attrs = { "_tool": attr.label(default = "//tools:tool") },
+)
+```
+
+```python
+# child.bzl
+load(":parent.bzl", "parent_rule")
+
+def _child_impl(ctx):
+    providers = ctx.super()  # runs the parent implementation
+    # additional child logic here
+    ...
+
+child_rule = rule(
+    implementation = _child_impl,
+    parent = parent_rule,
+)
+```
+
+`ctx.super()` invokes the parent rule's implementation function and returns its
+providers. It may be called at most once per implementation function.
+
+A parent rule can control whether it may be extended via the `extendable`
+parameter: `True` (always extendable, the default), `False` (never extendable),
+or a label pointing to an allowlist of packages permitted to extend it.
+
+Note that subrules are *not* inherited: a child rule that wants to call a subrule
+used by the parent must redeclare it in its own `subrules` parameter.
+
 ## Deprecated features
 
 ### Deprecated predeclared outputs

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkSubrule.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkSubrule.java
@@ -325,7 +325,16 @@ public class StarlarkSubrule implements StarlarkExportable, StarlarkCallable, St
   @StarlarkBuiltin(
       name = "subrule_ctx",
       category = DocCategory.BUILTIN,
-      doc = "A context object passed to the implementation function of a subrule.")
+      doc =
+          """
+          A context object passed to the implementation function of a subrule. It provides a
+          restricted API compared to the full rule context
+          (<a href="ctx.html">ctx</a>), with access only to the fields needed to
+          declare actions, access toolchains, read configuration fragments, and inspect
+          the label of the target being analyzed.
+          <p>The <code>subrule_ctx</code> is valid only during the execution of the
+          subrule's implementation function and cannot be used outside of it.
+          """)
   static class SubruleContext implements StarlarkActionContext {
     // these fields are effectively final, set to null once this instance is no longer usable by
     // Starlark
@@ -376,7 +385,14 @@ public class StarlarkSubrule implements StarlarkExportable, StarlarkCallable, St
 
     @StarlarkMethod(
         name = "toolchains",
-        doc = "Contains methods for declaring output files and the actions that produce them",
+        doc =
+            """
+            Provides access to the toolchains declared by this subrule. Only toolchains listed
+            in the <code>toolchains</code> parameter of the
+            <a href="../globals/bzl.html#subrule">subrule()</a> declaration are
+            accessible. Requires that the consuming rule has automatic exec-groups (AEGs)
+            enabled.
+            """,
         structField = true)
     public ToolchainContextApi toolchains() throws EvalException {
       checkMutable("toolchains");

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkRuleFunctionsApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkRuleFunctionsApi.java
@@ -727,14 +727,27 @@ declared.
             defaultValue = "None",
             positional = false,
             doc =
-                "Experimental: the Stalark rule that is extended. When set the public"
-                    + " attributes are merged as well as advertised providers. The rule matches"
-                    + " <code>executable</code> and <code>test</code> from the parent. Values of"
-                    + " <code>fragments</code>, <code>toolchains</code>,"
-                    + " <code>exec_compatible_with</code>, and <code>exec_groups</code> are"
-                    + " merged. Legacy or deprecated parameters may not be set. Incoming "
-                    + "configuration transition <code>cfg</code> of parent is applied after this"
-                    + "rule's incoming configuration."),
+                """
+                Experimental: A Starlark rule to extend. When set:
+                <ul>
+                <li>Public attributes declared on the parent are merged and accessible.</li>TODO what if there are conflicts?
+                <li>Providers advertised by the parent (<code>providers = [...]</code>) must be returned.</li>
+                <li><code>fragments</code>, <code>toolchains</code> and <code>exec_groups</code> are
+                merged and accessible.</li>TODO is this true?
+                <li>Execution platform constraints from the parent (<code>exec_compatible_with</code>
+                on <code>rule</code> and <code>exec_group</code>) are applied.</li>
+                <li>The incoming configuration transition (<code>cfg</code>) from the parent is applied
+                after the child rule's own incoming configuration transition.</li>
+                </ul>
+                <p><code>executable</code> and <code>test</code> must be the same as the parent rule.</p>
+                <p>The child rule's implementation can call <a href="../builtins/ctx.html#super">
+                <code>ctx.super()</code></a> to invoke the parent's implementation function and obtain
+                its providers. Note that the return value is a list of providers (not <code>Target</code>),
+                specific provider types cannot be accessed using index notation.</p>
+                <p>Legacy or deprecated <code>rule()</code> parameters may not be set on a child rule.
+                <p>See <a href="https://bazel.build/extending/rules#rule_inheritance">Rule
+                inheritance</a> for usage documentation.</p>
+                """),
         @Param(
             name = "extendable",
             named = true,
@@ -747,9 +760,17 @@ declared.
               @ParamType(type = NoneType.class),
             },
             doc =
-                "Experimental: A label of an allowlist defining which rules can extending this"
-                    + " rule. It can be set also to True/False to always allow/disallow extending."
-                    + " Bazel defaults to always allowing extensions."),
+                """
+                Experimental: Controls which other rules may extend this rule via the
+                <code>parent</code> parameter.
+                <ul>
+                  <li><code>True</code>: any rule may extend this one (the default).</li>
+                  <li><code>False</code>: this rule may not be extended.</li>
+                  <li>A label string or <code>Label</code>: points to a package-group or
+                      allowlist target; only rules in listed packages may extend this
+                      rule.</li>
+                </ul>
+                """),
         @Param(
             name = "subrules",
             allowedTypes = {
@@ -758,7 +779,11 @@ declared.
             named = true,
             defaultValue = "[]",
             positional = false,
-            doc = "Experimental: List of subrules used by this rule."),
+            doc =
+                """
+                Experimental: List of subrules used by this rule.
+                <p>See <a href="https://bazel.build/extending/rules#subrules">Subrules</a> for usage documentation.</p>
+                """),
       },
       useStarlarkThread = true)
   StarlarkCallable rule(
@@ -1084,12 +1109,31 @@ declared.
   @StarlarkMethod(
       name = "subrule",
       doc =
-          "Constructs a new instance of a subrule. The result of this function must be stored in "
-              + "a global variable before it can be used.",
+          """
+          Creates a new subrule. Subrules are a mechanism for sharing common implementation logic
+          between rules and aspects. A subrule encapsulates a piece of rule implementation
+          — typically actions that rely on private (implicit) tool or file dependencies —
+          that can be reused across multiple rules without duplicating attribute declarations.
+          <p>Rules and aspects that use a subrule must declare it in their
+          <code>subrules</code> parameter. The subrule's private attributes are
+          automatically lifted to the declaring rule or aspect, becoming invisible to
+          users of that rule.
+          <p>The result of this function must be assigned to a global variable in a .bzl
+          file before it can be called.
+          <p>See the
+          <a href="https://bazel.build/extending/rules#subrules">Rules page</a>
+          for usage documentation and examples.
+          """,
       parameters = {
         @Param(
             name = "implementation",
-            doc = "The Starlark function implementing this subrule",
+            doc =
+                """
+                The Starlark function implementing this subrule. It must accept a
+                <a href="../builtins/subrule_ctx.html">subrule_ctx</a> as its first
+                positional argument, followed by named parameters corresponding to each
+                entry in <code>attrs</code>.
+                """,
             named = true,
             positional = false,
             allowedTypes = {@ParamType(type = StarlarkFunction.class)}),

--- a/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkSubruleApi.java
+++ b/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/StarlarkSubruleApi.java
@@ -25,9 +25,22 @@ import net.starlark.java.eval.StarlarkValue;
     name = "Subrule",
     category = DocCategory.BUILTIN,
     doc =
-        "Experimental: a building block for writing rules with shared code. For more information,"
-            + " please see the subrule proposal:"
-            + " https://docs.google.com/document/d/1RbNC88QieKvBEwir7iV5zZU08AaMlOzxhVkPnmKDedQ")
+        """
+        Represents a subrule: a reusable piece of rule implementation logic that can be shared
+        across multiple rules and aspects. A subrule is created via the
+        <a href="../globals/bzl.html#subrule"><code>subrule()</code></a> function.
+        <p>A subrule encapsulates private (implicit) attribute declarations and the
+        implementation function that uses them. When a rule or aspect declares a subrule
+        in its <code>subrules</code> parameter, the subrule's private attributes are
+        automatically added to that rule or aspect and are invisible to end users.
+        <p>A subrule may itself depend on other subrules by listing them in its own
+        <code>subrules</code> parameter, in which case the declaring rule or aspect must
+        only list the top-level subrule.
+        <p>A <code>Subrule</code> instance is callable from within a rule or aspect
+        implementation function. Calling it invokes the subrule's implementation with a
+        fresh <a href="../builtins/subrule_ctx.html">subrule_ctx</a> as the first
+        argument.
+        """)
 public interface StarlarkSubruleApi extends StarlarkValue {
 
   static Optional<String> getUserDefinedNameIfSubruleAttr(


### PR DESCRIPTION
Temporary holding to allow further refinement.

## TODO

- Subrule doc does not show how arguments are passed (just private attributes).
- Note that subrules may specify at most 1 toolchain.
  - Subrules can use other subrules with their own toolchain, so further decomposition can sometimes act as a workaround.
- Toolchains in subrules must use automatic exec-groups.
- Spawn actions _must not_ be given a `toolchain` argument (normal rule scopes use this to automatic exec-groups).